### PR TITLE
Async on resolve workaround

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,6 @@ Bun Image Transform allows you to do exactly this.
 
 ## How to installed it
 
-You will first need a minimum version of v1.0.3 of Bun.
-**_This version is not yet available, and without the changes from pull request oven-sh/bun#5477, the plugin will not be able to transform images with the Bun Runtime._**
-
 For now, Bun Image Transform is not yet available on NPM, but later on, you'll simply need to run a bun install of the package.
 
 ## Usages

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,8 +39,8 @@ function BunImageTransformPlugin(settings: {
         }
       }
 
-      build.onResolve({ filter: /&bunimg$/ }, async (args) => {
-        const path = resolve(dirname(args.importer), args.path);
+      build.onLoad({ filter: /&bunimg$/ }, async (args) => {
+        const path = args.path;
 
         const link = new URL(`file://${path}`);
 
@@ -63,7 +63,10 @@ function BunImageTransformPlugin(settings: {
           await access(generatedImage);
 
           return {
-            path: generatedImage,
+            contents: `
+              export {default} from ${JSON.stringify(generatedImage)}
+            `,
+            loader: "js",
           };
         } catch {
           let image = sharp(sourceFile);
@@ -96,7 +99,10 @@ function BunImageTransformPlugin(settings: {
           await image.toFile(generatedImage);
 
           return {
-            path: generatedImage,
+            contents: `
+              export {default} from ${JSON.stringify(generatedImage)}
+            `,
+            loader: "js",
           };
         }
       });


### PR DESCRIPTION
As mentioned in this comment https://github.com/oven-sh/bun/pull/5477#issuecomment-1722500610.

I have found a better solution to enable image transformation in the Bun Runtime.

This self PR removes the mention of the PR and the necessity for a specific version of Bun.
(And also, of course, a patch for the Bun Runtime)